### PR TITLE
Add Python versions to build environment (#20)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
 # Command to install dependencies
 install:
   - pip install -r requirements/ci.pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+os: linux
+dist: xenial
 language: python
 python:
   - "3.5"


### PR DESCRIPTION
Fixes issue #20 by adding Python 3.6 and 3.7 to the Travis CI build environments. This change is consistent with the versions specified in setup.py and solicited on the [Python Package Index (PyPI)]( https://pypi.org/project/klvdata/). Due to [OpenSSL dependencies of Python 3.7]( https://docs.travis-ci.com/user/languages/python/), changed the Travis CI build environment from Ubuntu Trusty to Ubuntu Xenial and explicitly specified the operating system as Linux.