### PR TITLE
Fixed TypeError was not being handled

### DIFF
--- a/klvdata/setparser.py
+++ b/klvdata/setparser.py
@@ -60,7 +60,7 @@ class SetParser(Element, metaclass=ABCMeta):
         for key, value in KLVParser(self.value, self.key_length):
             try:
                 self.items[key] = self.parsers[key](value)
-            except KeyError:
+            except (KeyError, TypeError):
                 self.items[key] = self._unknown_element(key, value)
 
     @classmethod


### PR DESCRIPTION
While parsing a specific KLV, the following `TypeError` was being thrown:
```
Can't instantiate abstract class RVTLocalSet with abstract methods _domain, _range
```

This pull resolves issue #27 .