### PR TITLE
Bug: when an element uses the "out of range" indicator (e.g., −32,768…

### DIFF
--- a/klvdata/element.py
+++ b/klvdata/element.py
@@ -57,6 +57,8 @@ class Element(metaclass=ABCMeta):
     @property
     def length(self):
         """bytes: Return the BER encoded byte length of self.value."""
+        if self is None or self.value is None:
+            return 0
         return ber_encode(len(self))
 
     def __bytes__(self):
@@ -65,6 +67,8 @@ class Element(metaclass=ABCMeta):
 
     def __len__(self):
         """Return the byte length of self.value."""
+        if self.value is None:
+            return 0
         return len(bytes(self.value))
 
     @abstractmethod

--- a/klvdata/elementparser.py
+++ b/klvdata/elementparser.py
@@ -119,12 +119,16 @@ class StringValue(BaseValue):
             self.value = bytes_to_str(value)
         except TypeError:
             self.value = value
+        #except ValueError:
+            #self.value = None
 
     def __bytes__(self):
         return str_to_bytes(self.value)
 
     def __str__(self):
-        return str(self.value)
+        if self.value is not None:
+            return str(self.value)
+        return ""
 
 
 class MappedElementParser(ElementParser, metaclass=ABCMeta):
@@ -152,12 +156,16 @@ class MappedValue(BaseValue):
             self.value = bytes_to_float(value, self._domain, self._range)
         except TypeError:
             self.value = value
+        #except ValueError:
+            #self.value = None
 
     def __bytes__(self):
         return float_to_bytes(self.value, self._domain, self._range)
 
     def __str__(self):
-        return format(self.value)
+        if self.value is not None:
+            return format(self.value)
+        return ""
 
     def __float__(self):
         return self.value

--- a/klvdata/elementparser.py
+++ b/klvdata/elementparser.py
@@ -119,8 +119,6 @@ class StringValue(BaseValue):
             self.value = bytes_to_str(value)
         except TypeError:
             self.value = value
-        #except ValueError:
-            #self.value = None
 
     def __bytes__(self):
         return str_to_bytes(self.value)
@@ -156,8 +154,6 @@ class MappedValue(BaseValue):
             self.value = bytes_to_float(value, self._domain, self._range)
         except TypeError:
             self.value = value
-        #except ValueError:
-            #self.value = None
 
     def __bytes__(self):
         return float_to_bytes(self.value, self._domain, self._range)

--- a/klvdata/setparser.py
+++ b/klvdata/setparser.py
@@ -62,6 +62,9 @@ class SetParser(Element, metaclass=ABCMeta):
                 self.items[key] = self.parsers[key](value)
             except KeyError:
                 self.items[key] = self._unknown_element(key, value)
+            except ValueError:
+                # print(f"ValueError key {key} has bad value '{value}'!\n")
+                self.items[key] = self._unknown_element(key, value)
 
     @classmethod
     def add_parser(cls, obj):
@@ -131,7 +134,7 @@ def str_dict(values):
 
     def per_item(value, indent=0):
         for item in value:
-            if isinstance(item):
+            if isinstance(item, Element):
                 out.append(indent * "\t" + str(item))
             else:
                 out.append(indent * "\t" + str(item))

--- a/klvdata/setparser.py
+++ b/klvdata/setparser.py
@@ -63,7 +63,6 @@ class SetParser(Element, metaclass=ABCMeta):
             except KeyError:
                 self.items[key] = self._unknown_element(key, value)
             except ValueError:
-                # print(f"ValueError key {key} has bad value '{value}'!\n")
                 self.items[key] = self._unknown_element(key, value)
 
     @classmethod
@@ -125,6 +124,8 @@ class SetParser(Element, metaclass=ABCMeta):
                 print(indent * "\t" + str(type(item)))
                 if hasattr(item, 'items'):
                     repeat(item.items.values(), indent+1)
+                else:
+                    print((indent+1) * "\t" + str(item.value))
 
         repeat(self.items.values())
 


### PR DESCRIPTION
… for a 16-bit int), ValueError is thrown. Instead of throwing, store an UnknownElement with a value of the original data. That way, at least user-level code can tell that the element was present and had a bad value, but the message was still valid (passes checksum). This can occur when GPS is not reporting valid values for SensorLatitude (tag 13) for example.