### PR TITLE
Map "error" and "out of range" values to None

### DIFF
--- a/klvdata/common.py
+++ b/klvdata/common.py
@@ -111,7 +111,6 @@ def linear_map(src_value, src_domain, dst_range):
     it should always fall within the src_domain. If not, that's a problem.
     """
     src_min, src_max, dst_min, dst_max = src_domain + dst_range
-    # assert(src_min <= src_value <= src_max)
 
     if not (src_min <= src_value <= src_max):
         raise ValueError
@@ -125,9 +124,13 @@ def linear_map(src_value, src_domain, dst_range):
     return dst_value
 
 
-def bytes_to_float(value, _domain, _range):
+def bytes_to_float(value, _domain, _range, error=None):
     """Convert the fixed point value self.value to a floating point value."""
     src_value = int().from_bytes(value, byteorder='big', signed=(min(_domain) < 0))
+
+    if src_value == error:
+        return None
+
     return linear_map(src_value, _domain, _range)
 
 
@@ -142,7 +145,7 @@ def ieee754_bytes_to_fp(value):
     else:
         raise ValueError
 
-def float_to_bytes(value, _domain, _range):
+def float_to_bytes(value, _domain, _range, _error):
     """Convert the fixed point value self.value to a floating point value."""
     # Some classes like MappedElement are calling float_to_bytes with arguments _domain
     # and _range in the incorrect order. The naming convention used is confusing and
@@ -150,7 +153,10 @@ def float_to_bytes(value, _domain, _range):
     src_domain, dst_range = _range, _domain
     src_min, src_max, dst_min, dst_max = src_domain + dst_range
     length = int((dst_max - dst_min - 1).bit_length() / 8)
-    dst_value = linear_map(value, src_domain=src_domain, dst_range=dst_range)
+    if value is None:
+        dst_value = _error
+    else:
+        dst_value = linear_map(value, src_domain=src_domain, dst_range=dst_range)
     return round(dst_value).to_bytes(length, byteorder='big', signed=(dst_min < 0))
 
 

--- a/klvdata/common.py
+++ b/klvdata/common.py
@@ -145,7 +145,7 @@ def ieee754_bytes_to_fp(value):
     else:
         raise ValueError
 
-def float_to_bytes(value, _domain, _range, _error):
+def float_to_bytes(value, _domain, _range, _error=None):
     """Convert the fixed point value self.value to a floating point value."""
     # Some classes like MappedElement are calling float_to_bytes with arguments _domain
     # and _range in the incorrect order. The naming convention used is confusing and

--- a/klvdata/common.py
+++ b/klvdata/common.py
@@ -124,11 +124,11 @@ def linear_map(src_value, src_domain, dst_range):
     return dst_value
 
 
-def bytes_to_float(value, _domain, _range, error=None):
+def bytes_to_float(value, _domain, _range, _error=None):
     """Convert the fixed point value self.value to a floating point value."""
     src_value = int().from_bytes(value, byteorder='big', signed=(min(_domain) < 0))
 
-    if src_value == error:
+    if src_value == _error:
         return None
 
     return linear_map(src_value, _domain, _range)

--- a/klvdata/elementparser.py
+++ b/klvdata/elementparser.py
@@ -133,7 +133,7 @@ class StringValue(BaseValue):
 
 class MappedElementParser(ElementParser, metaclass=ABCMeta):
     def __init__(self, value):
-        super().__init__(MappedValue(value, self._domain, self._range))
+        super().__init__(MappedValue(value, self._domain, self._range, self._error))
 
     @property
     @classmethod
@@ -147,18 +147,25 @@ class MappedElementParser(ElementParser, metaclass=ABCMeta):
     def _range(cls):
         pass
 
+    @property
+    @classmethod
+    @abstractmethod
+    def _error(cls):
+        pass
+
 class MappedValue(BaseValue):
-    def __init__(self, value, _domain, _range):
+    def __init__(self, value, _domain, _range, _error):
         self._domain = _domain
         self._range = _range
+        self._error = _error
 
         try:
-            self.value = bytes_to_float(value, self._domain, self._range)
+            self.value = bytes_to_float(value, self._domain, self._range, self._error)
         except TypeError:
             self.value = value
 
     def __bytes__(self):
-        return float_to_bytes(self.value, self._domain, self._range)
+        return float_to_bytes(self.value, self._domain, self._range, self._error)
 
     def __str__(self):
         if self.value is not None:

--- a/klvdata/misb0601.py
+++ b/klvdata/misb0601.py
@@ -120,6 +120,7 @@ class PlatformHeadingAngle(MappedElementParser):
     UDSName = "Platform Heading Angle"
     _domain = (0, 2**16-1)
     _range = (0, 360)
+    _error = None
 
 
 @UASLocalMetadataSet.add_parser
@@ -132,6 +133,7 @@ class PlatformPitchAngle(MappedElementParser):
     UDSName = "Platform Pitch Angle"
     _domain = (-(2**15-1), 2**15-1)
     _range = (-20, 20)
+    _error = -2**15
 
 
 @UASLocalMetadataSet.add_parser
@@ -144,6 +146,7 @@ class PlatformRollAngle(MappedElementParser):
     UDSName = "Platform Roll Angle"
     _domain = (-(2**15-1), 2**15-1)
     _range = (-50, 50)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -157,6 +160,7 @@ class PlatformTrueAirspeed(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 255)
+    _error = None
     units = 'meters/second'
 
 
@@ -170,6 +174,7 @@ class PlatformIndicatedAirspeed(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 255)
+    _error = None
     units = 'meters/second'
 
 
@@ -216,6 +221,7 @@ class SensorLatitude(MappedElementParser):
     UDSName = "Device Latitude"
     _domain = (-(2**31-1), 2**31-1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -229,6 +235,7 @@ class SensorLongitude(MappedElementParser):
     UDSName = "Device Longitude"
     _domain = (-(2**31-1), 2**31-1)
     _range = (-180, 180)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -242,6 +249,7 @@ class SensorTrueAltitude(MappedElementParser):
     UDSName = "Device Altitude"
     _domain = (0, 2**16-1)
     _range = (-900, 19000)
+    _error = None
     units = 'meters'
 
 
@@ -255,6 +263,7 @@ class SensorHorizontalFieldOfView(MappedElementParser):
     UDSName = "Field of View (FOVHorizontal)"
     _domain = (0, 2**16-1)
     _range = (0, 180)
+    _error = None
     units = 'degrees'
 
 
@@ -268,6 +277,7 @@ class SensorVerticalFieldOfView(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (0, 180)
+    _error = None
     units = 'degrees'
 
 
@@ -281,6 +291,7 @@ class SensorRelativeAzimuthAngle(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**32-1)
     _range = (0, 360)
+    _error = None
     units = 'degrees'
 
 
@@ -294,6 +305,7 @@ class SensorRelativeElevationAngle(MappedElementParser):
     UDSName = ""
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-180, 180)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -307,6 +319,7 @@ class SensorRelativeRollAngle(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**32-1)
     _range = (0, 360)
+    _error = None
     units = 'degrees'
 
 
@@ -320,6 +333,7 @@ class SlantRange(MappedElementParser):
     UDSName = "Slant Range"
     _domain = (0, 2**32-1)
     _range = (0, +5e6)
+    _error = None
     units = 'meters'
 
 
@@ -333,6 +347,7 @@ class TargetWidth(MappedElementParser):
     UDSName = "Target Width"
     _domain = (0, 2**16-1)
     _range = (0, +10e3)
+    _error = None
     units = 'meters'
 
 
@@ -346,6 +361,7 @@ class FrameCenterLatitude(MappedElementParser):
     UDSName = "Frame Center Latitude"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -359,6 +375,7 @@ class FrameCenterLongitude(MappedElementParser):
     UDSName = "Frame Center Longitude"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-180, 180)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -372,6 +389,7 @@ class FrameCenterElevation(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (-900, +19e3)
+    _error = None
     units = 'meters'
 
 
@@ -385,6 +403,7 @@ class OffsetCornerLatitudePoint1(MappedElementParser):
     UDSName = "Corner Latitude Point 1"
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-0.075, +0.075)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -398,6 +417,7 @@ class OffsetCornerLongitudePoint1(MappedElementParser):
     UDSName = "Corner Longitude Point 1"
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-0.075, 0.075)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -411,6 +431,7 @@ class OffsetCornerLatitudePoint2(MappedElementParser):
     UDSName = "Corner Latitude Point 2"
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-0.075, 0.075)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -424,6 +445,7 @@ class OffsetCornerLongitudePoint2(MappedElementParser):
     UDSName = "Corner Longitude Point 2"
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-0.075, 0.075)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -437,6 +459,7 @@ class OffsetCornerLatitudePoint3(MappedElementParser):
     UDSName = "Corner Latitude Point 3"
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-0.075, 0.075)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -450,6 +473,7 @@ class OffsetCornerLongitudePoint3(MappedElementParser):
     UDSName = "Corner Longitude Point 3"
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-0.075, 0.075)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -463,6 +487,7 @@ class OffsetCornerLatitudePoint4(MappedElementParser):
     UDSName = "Corner Latitude Point 4"
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-0.075, 0.075)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -476,6 +501,7 @@ class OffsetCornerLongitudePoint4(MappedElementParser):
     UDSName = "Corner Longitude Point 4"
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-0.075, 0.075)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -489,6 +515,7 @@ class IcingDetected(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 2**8-1)
+    _error = None
     units = 'flag'
 
 
@@ -502,6 +529,7 @@ class WindDirection(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16 - 1)
     _range = (0, +360)
+    _error = None
     units = 'meters/second'
 
 
@@ -515,6 +543,7 @@ class WindSpeed(MappedElementParser):
     UDSName = ""
     _domain = (0, 255)
     _range = (0, +100)
+    _error = None
     units = 'meters/second'
 
 
@@ -528,6 +557,7 @@ class StaticPressure(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16 - 1)
     _range = (0, +5000)
+    _error = None
     units = 'millibar'
 
 
@@ -541,6 +571,7 @@ class DensityAltitude(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16 - 1)
     _range = (-900, +19e3)
+    _error = None
     units = 'meters'
 
 
@@ -554,6 +585,7 @@ class OutsideAirTemperature(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 2**8-1)
+    _error = None
     units = 'celcius'
 
 
@@ -567,6 +599,7 @@ class TargetLocationLatitude(MappedElementParser):
     UDSName = ""
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -580,6 +613,7 @@ class TargetLocationLongitude(MappedElementParser):
     UDSName = ""
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-180, 180)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -593,6 +627,7 @@ class TargetLocationElevation(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (-900, 19000)
+    _error = None
     units = 'meters'
 
 
@@ -606,6 +641,7 @@ class TargetTrackGateWidth(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 512)
+    _error = None
     units = 'pixels'
 
 
@@ -619,6 +655,7 @@ class TargetTrackGateHeight(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 512)
+    _error = None
     units = 'pixels'
 
 
@@ -632,6 +669,7 @@ class TargetErrorEstimateCE90(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (0, 4095)
+    _error = None
     units = 'meters'
 
 
@@ -645,6 +683,7 @@ class TargetErrorEstimateLE90(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (0, 4095)
+    _error = None
     units = 'meters'
 
 
@@ -658,6 +697,7 @@ class GenericFlagData01(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 2**8-1)
+    _error = None
 
 
 # @UASLocalMetadataSet.add_parser
@@ -680,6 +720,7 @@ class DifferentialPressure(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (0, 5000)
+    _error = None
     units = 'millibar'
 
 
@@ -693,6 +734,7 @@ class PlatformAngleOfAttack(MappedElementParser):
     UDSName = ""
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-20, 20)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -706,6 +748,7 @@ class PlatformVerticalSpeed(MappedElementParser):
     UDSName = ""
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-180, 180)
+    _error = -2**15
     units = 'meters/second'
 
 
@@ -719,6 +762,7 @@ class PlatformSideslipAngle(MappedElementParser):
     UDSName = ""
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-20, 20)
+    _error = -2**15
     units = 'degrees'
 
 
@@ -732,6 +776,7 @@ class AirfieldBarometricPressure(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (0, 5000)
+    _error = None
     units = 'millibar'
 
 
@@ -745,6 +790,7 @@ class AirfieldElevation(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (-900, 19000)
+    _error = None
     units = 'meters'
 
 
@@ -758,6 +804,7 @@ class RelativeHumidity(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 100)
+    _error = None
     units = '%'
 
 
@@ -771,6 +818,7 @@ class PlatformGroundSpeed(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 255)
+    _error = None
     units = 'meters/second'
 
 
@@ -784,6 +832,7 @@ class GroundRange(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**32-1)
     _range = (0, 5000000)
+    _error = None
     units = 'meters'
 
 
@@ -797,6 +846,7 @@ class PlatformFuelRemaining(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (0, 10000)
+    _error = None
     units = 'kilograms'
 
 
@@ -820,6 +870,7 @@ class WeaponLoad(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (0, 2**16-1)
+    _error = None
 
 @UASLocalMetadataSet.add_parser
 class WeaponFired(MappedElementParser):
@@ -831,6 +882,7 @@ class WeaponFired(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 2**8-1)
+    _error = None
 
 
 @UASLocalMetadataSet.add_parser
@@ -843,6 +895,7 @@ class LaserPRFCode(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (0, 65535)
+    _error = None
 
 @UASLocalMetadataSet.add_parser
 class SensorFieldOfViewName(MappedElementParser):
@@ -854,6 +907,7 @@ class SensorFieldOfViewName(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 2**8-1)
+    _error = None
 
 @UASLocalMetadataSet.add_parser
 class PlatformMagneticHeading(MappedElementParser):
@@ -865,6 +919,7 @@ class PlatformMagneticHeading(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (0, 360)
+    _error = None
     units = 'degrees'
 
 
@@ -878,6 +933,7 @@ class UASLSVersionNumber(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**8-1)
     _range = (0, 2**8-1)
+    _error = None
     units = 'number'
 
 
@@ -891,6 +947,7 @@ class AlternatePlatformLatitude(MappedElementParser):
     UDSName = ""
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -904,6 +961,7 @@ class AlternatePlatformLongitude(MappedElementParser):
     UDSName = ""
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-180, 180)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -917,6 +975,7 @@ class AlternatePlatformAltitude(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16 - 1)
     _range = (-900, 19000)
+    _error = None
     units = 'meters'
 
 
@@ -941,6 +1000,7 @@ class AlternatePlatformHeading(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16 - 1)
     _range = (0, 360)
+    _error = None
     units = 'degrees'
 
 
@@ -984,6 +1044,7 @@ class SensorEllipsoidHeightConversion(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (-900, 19000)
+    _error = None
     units = 'meters'
 
 
@@ -997,6 +1058,7 @@ class AlternatePlatformEllipsoidHeight(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (-900, 19000)
+    _error = None
     units = 'meters'
 
 
@@ -1020,6 +1082,7 @@ class FrameCenterHeightAboveEllipsoid(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (-900, 19000)
+    _error = None
     units = 'meters'
 
 
@@ -1033,6 +1096,7 @@ class SensorNorthVelocity(MappedElementParser):
     UDSName = ""
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-327, 327)
+    _error = -2**15
     units = 'meters/second'
 
 
@@ -1046,6 +1110,7 @@ class SensorEastVelocity(MappedElementParser):
     UDSName = ""
     _domain = (-(2**15 - 1), 2**15 - 1)
     _range = (-327, 327)
+    _error = -2**15
     units = 'meters/second'
 
 # @UASLocalMetadataSet.add_parser
@@ -1068,6 +1133,7 @@ class CornerLatitudePoint1Full(MappedElementParser):
     UDSName = "Corner Latitude Point 1 (Decimal Degrees)"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1081,6 +1147,7 @@ class CornerLongitudePoint1Full(MappedElementParser):
     UDSName = "Corner Longitude Point 1 (Decimal Degrees)"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-180, 180)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1094,6 +1161,7 @@ class CornerLatitudePoint2Full(MappedElementParser):
     UDSName = "Corner Latitude Point 2 (Decimal Degrees)"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1107,6 +1175,7 @@ class CornerLongitudePoint2Full(MappedElementParser):
     UDSName = "Corner Longitude Point 2 (Decimal Degrees)"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-180, 180)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1120,6 +1189,7 @@ class CornerLatitudePoint3Full(MappedElementParser):
     UDSName = "Corner Latitude Point 3 (Decimal Degrees)"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1133,6 +1203,7 @@ class CornerLongitudePoint3Full(MappedElementParser):
     UDSName = "Corner Longitude Point 3 (Decimal Degrees)"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-180, 180)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1146,6 +1217,7 @@ class CornerLatitudePoint4Full(MappedElementParser):
     UDSName = "Corner Latitude Point 4 (Decimal Degrees)"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1159,6 +1231,7 @@ class CornerLongitudePoint4Full(MappedElementParser):
     UDSName = "Corner Longitude Point 4 (Decimal Degrees)"
     _domain = (-(2**31 - 1), 2**31 - 1)
     _range = (-180, 180)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1172,6 +1245,7 @@ class PlatformPitchAngleFull(MappedElementParser):
     UDSName = "Platform Pitch Angle"
     _domain = (-(2**31-1), 2**31-1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1185,6 +1259,7 @@ class PlatformRollAngleFull(MappedElementParser):
     UDSName = "Platform Roll Angle"
     _domain = (-(2**31-1), 2**31-1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1198,6 +1273,7 @@ class PlatformAngleOfAttackFull(MappedElementParser):
     UDSName = ""
     _domain = (-(2**31-1), 2**31-1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1211,6 +1287,7 @@ class PlatformSideslipAngleFull(MappedElementParser):
     UDSName = ""
     _domain = (-(2**31-1), 2**31-1)
     _range = (-90, 90)
+    _error = -2**31
     units = 'degrees'
 
 
@@ -1244,6 +1321,7 @@ class TargetWidthExtended(MappedElementParser):
     UDSName = "Target Width"
     _domain = (0, 2**8-1)
     _range = (0, 2**8-1)
+    _error = None
     units = 'meters'
 
 
@@ -1257,6 +1335,7 @@ class DensityAltitudeExtended(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (-900, 40000)
+    _error = None
     units = 'meters'
 
 @UASLocalMetadataSet.add_parser
@@ -1269,6 +1348,7 @@ class SensorEllipsoidHeightExtended(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (-900, 40000)
+    _error = None
     units = 'meters'
 
 
@@ -1282,4 +1362,5 @@ class AlternatePlatformEllipsoidHeightExtended(MappedElementParser):
     UDSName = ""
     _domain = (0, 2**16-1)
     _range = (-900, 40000)
+    _error = None
     units = 'meters'

--- a/klvdata/misbEG0104.py
+++ b/klvdata/misbEG0104.py
@@ -265,7 +265,7 @@ class SensorRelativeAzimuthAngle(IEEE754ElementParser):
     _domain = (0, 2 ** 32 - 1)
     _range = (0, 360)
     units = 'degrees'
- 
+
 @UAVBasicUniversalMetadataSet.add_parser 
 class SensorRelativeElevationAngle(IEEE754ElementParser):
     key = hexstr_to_bytes("06 0e 2b 34 01 01 01 01 07 01 10 01 03 00 00 00")
@@ -601,24 +601,25 @@ class PlatformRollAngleFull(IEEE754ElementParser):
     _range = (-90, 90)
     units = 'degrees'
 
+
 @UAVBasicUniversalMetadataSet.add_parser
 class MIISCoreIdentifier(StringElementParser):
-     key = hexstr_to_bytes("06 0E 2B 34 01 01 01 01 0E 01 04 05 03 00 00 00")
-     TAG = 94
-     UDSKey = "06 0E 2B 34 01 01 01 01 0E 01 04 05 03 00 00 00"
-     LDSName = "MIIS Core Identifier"
-     ESDName = ""
-     UDSName = "Motion Imagery Identification System Core"
+    key = hexstr_to_bytes("06 0E 2B 34 01 01 01 01 0E 01 04 05 03 00 00 00")
+    TAG = 94
+    UDSKey = "06 0E 2B 34 01 01 01 01 0E 01 04 05 03 00 00 00"
+    LDSName = "MIIS Core Identifier"
+    ESDName = ""
+    UDSName = "Motion Imagery Identification System Core"
 
 
 @UAVBasicUniversalMetadataSet.add_parser
 class SARMotionImageryLocalSet(StringElementParser):
-     key = hexstr_to_bytes("06 0E 2B 34 02 0B 01 01 0E 01 03 03 0D 00 00 00")
-     TAG = 95
-     UDSKey = "06 0E 2B 34 02 0B 01 01 0E 01 03 03 0D 00 00 00"
-     LDSName = "SAR Motion Imagery Local Set"
-     ESDName = ""
-     UDSName = "SAR Motion Imagery Local Set"
+    key = hexstr_to_bytes("06 0E 2B 34 02 0B 01 01 0E 01 03 03 0D 00 00 00")
+    TAG = 95
+    UDSKey = "06 0E 2B 34 02 0B 01 01 0E 01 03 03 0D 00 00 00"
+    LDSName = "SAR Motion Imagery Local Set"
+    ESDName = ""
+    UDSName = "SAR Motion Imagery Local Set"
 
 
 @UAVBasicUniversalMetadataSet.add_parser
@@ -670,4 +671,3 @@ class AlternatePlatformEllipsoidHeightExtended(IEEE754ElementParser):
     _domain = (0, 2**16-1)
     _range = (-900, 40000)
     units = 'meters'
-


### PR DESCRIPTION
The [ST0601.11 standard](https://www.gwg.nga.mil/misb/docs/standards/ST0601.11.pdf) provides for certain "error" and "out of range" values (see for example Sensor Latitude in the table on page 17). These values currently trigger ValueErrors when the library attempts to parse them. This PR proposes instead to map them to a value of None.

*This is my first time attempting to contribute to anything public, so apologies if I'm doing it wrong or stepping on toes.

Fix issue #40 